### PR TITLE
Update dependencies and make web3 optional

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,5 +9,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
+      - run: cargo clippy --all-features --all-targets -- -D warnings
+      - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,15 @@ async-trait = "0.1"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.6"
-web3 = { version = "0.13", default-features = false }
-primitive-types = { version = "0.7.3", features = ["fp-conversion"] }
+web3 = { version = "0.15", default-features = false, optional = true }
+primitive-types = { version = "0.8", features = ["fp-conversion"], optional = true }
+
+[features]
+web3_ = ["web3", "primitive-types"]
 
 [dev-dependencies]
 assert_approx_eq = "1.1"
 futures = "0.3"
 isahc = { version = "0.9", features = ["json"] }
-mockall = "0.8"
+mockall = "0.9"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! # Features
+//! `web3_`: Implements `GasPriceEstimating` for `Web3`.
+
+#[cfg(feature = "web3_")]
 mod eth_node;
 mod ethgasstation;
 mod gasnow;


### PR DESCRIPTION
Web3 is optional because it is a big dependency so that felt more appropriate even though we are using it.