### PR TITLE
Enforce gas now rate limit with cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,18 +6,18 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+futures = "0.3"
 log = "0.4"
+primitive-types = { version = "0.8", features = ["fp-conversion"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.6"
 web3 = { version = "0.15", default-features = false, optional = true }
-primitive-types = { version = "0.8", features = ["fp-conversion"], optional = true }
 
 [features]
 web3_ = ["web3", "primitive-types"]
 
 [dev-dependencies]
 assert_approx_eq = "1.1"
-futures = "0.3"
-isahc = { version = "0.9", features = ["json"] }
+isahc = { version = "1.0", features = ["json"] }
 mockall = "0.9"
 serde_json = "1.0"

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -1,23 +1,37 @@
 use super::{linear_interpolation, GasPriceEstimating, Transport};
-use anyhow::Result;
-use std::{convert::TryInto, time::Duration};
+use anyhow::{anyhow, Result};
+use futures::lock::Mutex;
+use std::{
+    convert::TryInto,
+    future::Future,
+    time::{Duration, Instant},
+};
 
 // Gas price estimation with https://www.gasnow.org/ , api at https://taichi.network/#gasnow .
 
 const API_URI: &str = "https://www.gasnow.org/api/v3/gas/price";
+const RATE_LIMIT: Duration = Duration::from_secs(15);
 
 pub struct GasNowGasStation<T> {
     transport: T,
+    last_response: Mutex<Option<CachedResponse>>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+struct CachedResponse {
+    // The time at which the request was sent.
+    time: Instant,
+    // The result of the last response. Error isn't Clone so we store None in the error case.
+    data: Option<Response>,
+}
+
+#[derive(Clone, Copy, Debug, Default, serde::Deserialize, PartialEq)]
 struct Response {
     code: u32,
     data: ResponseData,
 }
 
 // gas prices in wei
-#[derive(Debug, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Default, serde::Deserialize, PartialEq)]
 struct ResponseData {
     rapid: f64,
     fast: f64,
@@ -32,18 +46,53 @@ const SLOW: Duration = Duration::from_secs(600);
 
 impl<T: Transport> GasNowGasStation<T> {
     pub fn new(transport: T) -> Self {
-        Self { transport }
+        Self {
+            transport,
+            last_response: Default::default(),
+        }
     }
 
-    async fn gas_price(&self) -> Result<Response> {
+    async fn gas_price_without_cache(&self) -> Result<Response> {
         self.transport.get_json(API_URI).await
+    }
+
+    // Ensures that no requests are made faster than the rate limit by caching the previous
+    // response. Errors are part of the cache.
+    async fn gas_price_with_cache<Fut>(
+        &self,
+        now: Instant,
+        fetch: impl FnOnce() -> Fut,
+    ) -> Result<Response>
+    where
+        Fut: Future<Output = Result<Response>>,
+    {
+        let mut lock = self.last_response.lock().await;
+        match lock.as_ref() {
+            Some(cached) if now.duration_since(cached.time) < RATE_LIMIT => match cached.data {
+                Some(response) => Ok(response),
+                None => Err(anyhow!(
+                    "previous response was error and cache has not yet expired"
+                )),
+            },
+            _ => {
+                let result = fetch().await;
+                *lock = Some(CachedResponse {
+                    time: now,
+                    data: result.as_ref().ok().copied(),
+                });
+                result
+            }
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl<T: Transport> GasPriceEstimating for GasNowGasStation<T> {
     async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
-        let response = self.gas_price().await?.data;
+        let response = self
+            .gas_price_with_cache(Instant::now(), || self.gas_price_without_cache())
+            .await?
+            .data;
         let points: &[(f64, f64)] = &[
             (RAPID.as_secs_f64(), response.rapid),
             (FAST.as_secs_f64(), response.fast),
@@ -60,13 +109,83 @@ impl<T: Transport> GasPriceEstimating for GasNowGasStation<T> {
 mod tests {
     use super::super::tests::{FutureWaitExt as _, TestTransport};
     use super::*;
+    use std::future::{ready, Pending};
 
-    // cargo test -p services-core gasnow -- --ignored --nocapture
+    fn panic_future() -> Pending<Result<Response>> {
+        panic!()
+    }
+
+    #[test]
+    fn cache_works_ok() {
+        let gasnow = GasNowGasStation::new(TestTransport::default());
+        let now = Instant::now();
+        let response = Response {
+            code: 0,
+            ..Default::default()
+        };
+
+        // insert value into cache
+        gasnow
+            .gas_price_with_cache(now, || ready(Ok(response)))
+            .wait()
+            .unwrap();
+        // panic_future isn't called
+        assert_eq!(
+            gasnow
+                .gas_price_with_cache(now, panic_future)
+                .wait()
+                .unwrap(),
+            response
+        );
+
+        // cache gets updated after expiry
+        let now = now + RATE_LIMIT;
+        let response = Response {
+            code: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            gasnow
+                .gas_price_with_cache(now, || ready(Ok(response)))
+                .wait()
+                .unwrap(),
+            response
+        );
+        assert_eq!(
+            gasnow
+                .gas_price_with_cache(now, panic_future)
+                .wait()
+                .unwrap(),
+            response
+        );
+    }
+
+    #[test]
+    fn cache_remembers_error() {
+        let gasnow = GasNowGasStation::new(TestTransport::default());
+        let now = Instant::now();
+
+        assert!(gasnow
+            .gas_price_with_cache(now, || ready(Err(anyhow!(""))))
+            .wait()
+            .is_err());
+        // panic_future isn't called
+        assert!(gasnow
+            .gas_price_with_cache(now, panic_future)
+            .wait()
+            .is_err());
+    }
+
+    // cargo test gasnow -- --ignored --nocapture
     #[test]
     #[ignore]
     fn real_request() {
         let gasnow = GasNowGasStation::new(TestTransport::default());
-        let response = gasnow.gas_price().wait();
-        println!("{:?}", response);
+        loop {
+            let before = Instant::now();
+            let response = gasnow.estimate().wait();
+            println!("{:?} in {} s", response, before.elapsed().as_secs_f32());
+            std::thread::sleep(Duration::from_secs(1));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,13 @@ pub trait GasPriceEstimating: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait Transport: Send + Sync {
-    async fn get_json<'a, T: DeserializeOwned>(&self, url: &'a str) -> Result<T>;
+    async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use isahc::{http::uri::Uri, ResponseExt};
+    use isahc::{http::uri::Uri, AsyncReadResponseExt};
     use std::{future::Future, str::FromStr};
 
     #[derive(Default)]
@@ -49,8 +49,8 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Transport for TestTransport {
-        async fn get_json<'a, T: DeserializeOwned>(&self, url: &'a str) -> Result<T> {
-            let json: String = isahc::get_async(Uri::from_str(url)?).await?.text()?;
+        async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
+            let json: String = isahc::get_async(Uri::from_str(url)?).await?.text().await?;
             Ok(serde_json::from_str(&json)?)
         }
     }


### PR DESCRIPTION
Because https://github.com/gnosis/gp-v2-services/pull/558 will use the gas estimator a lot more.

Also updated dependencies and removed unnecessary lifetime from Transport trait.

The gas now api has a rate limit of 15 seconds (https://taichi.network/#gasnow) which this PR is enforcing using a cache. If a request has been made in the last 15 seconds then we return a copy of that response. This includes errors so if a new cache entry is made from an error, the error will be returned for all requests in the next 15 seconds.
Alternatively we could return the previous successful result but it is safer to propagate the error because that would break for example the priority estimator.
This is not a generic CachingGasPriceEstimator because caching on the trait level doesn't allow for the same granularity as it depends on specific gas use and time limits. Whereas with this version we cache the underlying data the computation is performed on.

Future Idea: use the websocket api to subscribe to gas updates. Rate limits would be enforced automatically because we're no longer polling.