### PR TITLE
Add trait for configuring GasNow WebSocket error reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 anyhow = "1.0"
 async-trait = "0.1"
 futures = "0.3"
-log = "0.4"
 primitive-types = { version = "0.9", features = ["fp-conversion"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -48,9 +48,9 @@ impl PriorityGasPriceEstimating {
                 Err(err) => {
                     let num_errors = estimator.errors_in_a_row.fetch_add(1, Ordering::SeqCst) + 1;
                     if num_errors < LOG_ERROR_AFTER_N_ERRORS {
-                        log::warn!("gas estimator {} failed: {:?}", i, err);
+                        tracing::warn!("gas estimator {} failed: {:?}", i, err);
                     } else {
-                        log::error!("gas estimator {} failed: {:?}", i, err);
+                        tracing::error!("gas estimator {} failed: {:?}", i, err);
                     }
                 }
             }


### PR DESCRIPTION
This PR adds a trait for reporting errors in the gas now WebSocket-based gas price estimator. This way, we can configure custom error handling (such as adding metrics) in `gp-v2-services` as well as remove some of the pesky error alerts we were seeing.

### Test Plan

Not sure what to run, just did `cargo fmt -- --check && cargo clippy --all-features --all-targets && cargo test`.