### PR TITLE
implement blocknative gas estimator for legacy type of transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ tokio-tungstenite = { version = "0.15", features = ["native-tls"], optional = tr
 tracing = "0.1"
 url = "2.0"
 web3 = { version = "0.17", default-features = false, optional = true }
+http = "0.2.4"
+reqwest = { version = "0.11", features = ["json"] }
 
 [features]
 tokio_ = ["tokio", "tokio-tungstenite"]
@@ -23,7 +25,6 @@ web3_ = ["web3", "primitive-types"]
 
 [dev-dependencies]
 assert_approx_eq = "1.1"
-isahc = { version = "1.0", features = ["json"] }
 mockall = "0.9"
 serde_json = "1.0"
 tokio = { version = "1.9", features = ["macros", "rt", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ tracing = "0.1"
 url = "2.0"
 web3 = { version = "0.17", default-features = false, optional = true }
 http = "0.2.4"
-reqwest = { version = "0.11", features = ["json"] }
 
 [features]
 tokio_ = ["tokio", "tokio-tungstenite"]
@@ -29,3 +28,4 @@ mockall = "0.9"
 serde_json = "1.0"
 tokio = { version = "1.9", features = ["macros", "rt", "time"] }
 tracing-subscriber = "0.2"
+reqwest = { version = "0.11", features = ["json"] }

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -1,0 +1,129 @@
+use super::{GasPriceEstimating, Transport};
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use std::time::Duration;
+
+// Gas price estimation with https://www.blocknative.com/gas-estimator , api https://docs.blocknative.com/gas-platform#example-request .
+
+const API_URI: &str = "https://api.blocknative.com/gasprices/blockprices";
+
+pub struct BlockNative<T> {
+    transport: T,
+    api_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EstimatedPrice {
+    confidence: u64,
+    price: f64,
+    max_priority_fee_per_gas: f64,
+    max_fee_per_gas: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BlockPrice {
+    estimated_prices: Vec<EstimatedPrice>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Response {
+    block_prices: Vec<BlockPrice>,
+}
+
+impl<T: Transport> BlockNative<T> {
+    pub fn new(transport: T, api_key: String) -> Self {
+        Self { transport, api_key }
+    }
+
+    async fn gas_price(&self) -> Result<Response> {
+        self.transport
+            .get_json(API_URI, Some(self.api_key.clone()))
+            .await
+            .context("failed to get blocknative gas price")
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: Transport> GasPriceEstimating for BlockNative<T> {
+    async fn estimate_with_limits(&self, _gas_limit: f64, _time_limit: Duration) -> Result<f64> {
+        let response = self.gas_price().await?;
+        if let Some(block) = response.block_prices.first() {
+            if let Some(estimated_price) = block.estimated_prices.first() {
+                return Ok(estimated_price.price);
+            }
+        }
+        return Err(anyhow!("invalid response from blocknative"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{FutureWaitExt as _, TestTransport};
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    #[ignore]
+    fn real_request() {
+        let blocknative = BlockNative::new(
+            TestTransport::default(),
+            std::env::var("BLOCKNATIVE_API_KEY").unwrap(), //or replace with api_key
+        );
+        let _response = blocknative.gas_price().wait().unwrap();
+    }
+
+    #[test]
+    fn deserialize_response() {
+        let json = json!({
+          "system": "ethereum",
+          "network": "main",
+          "unit": "gwei",
+          "maxPrice": "123",
+          "currentBlockNumber": "13005095",
+          "msSinceLastBlock": "3793",
+          "blockPrices": [
+            {
+              "blockNumber": "13005096",
+              "baseFeePerGas": "94.647990462",
+              "estimatedTransactionCount": "137",
+              "estimatedPrices": [
+                {
+                  "confidence": 99,
+                  "price": 104,
+                  "maxPriorityFeePerGas": 9.86,
+                  "maxFeePerGas": 199.16
+                },
+                {
+                  "confidence": 95,
+                  "price": 99,
+                  "maxPriorityFeePerGas": 5.06,
+                  "maxFeePerGas": 194.35
+                },
+                {
+                  "confidence": 90,
+                  "price": 98,
+                  "maxPriorityFeePerGas": 4.16,
+                  "maxFeePerGas": 193.45
+                },
+                {
+                  "confidence": 80,
+                  "price": 97,
+                  "maxPriorityFeePerGas": 2.97,
+                  "maxFeePerGas": 192.27
+                },
+                {
+                  "confidence": 70,
+                  "price": 96,
+                  "maxPriorityFeePerGas": 1.74,
+                  "maxFeePerGas": 191.04
+                }
+              ]
+            }
+          ]
+        });
+        let _response: Response = serde_json::from_value(json).unwrap();
+    }
+}

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -122,13 +122,15 @@ impl BlockNative {
 #[async_trait::async_trait]
 impl GasPriceEstimating for BlockNative {
     async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
-        match self.cached_response.lock() {
-            Ok(cached_response) => estimate_with_limits(time_limit, cached_response.clone()),
+        let cached_response = match self.cached_response.lock() {
+            Ok(cached_response) => cached_response.clone(),
             Err(e) => {
                 tracing::warn!(?e, "failed to obtain lock on cached response");
                 return Err(anyhow!("failed to obtain lock on cached response"));
             }
-        }
+        };
+
+        estimate_with_limits(time_limit, cached_response)
     }
 }
 

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -171,7 +171,7 @@ fn estimate_with_limits(
         ));
     }
 
-    return Err(anyhow!("no valid response exist"));
+    Err(anyhow!("no valid response exist"))
 }
 
 #[cfg(test)]
@@ -284,14 +284,14 @@ mod tests {
         };
 
         let price = estimate_with_limits(Duration::from_secs(10), cached_response.clone()).unwrap();
-        assert_eq!(price, 104.0);
+        assert_eq!(price, f64::from(104.0));
         let price = estimate_with_limits(Duration::from_secs(16), cached_response.clone()).unwrap();
-        assert_eq!(price, 98.76);
+        assert_eq!(price, f64::from(98.76));
         let price = estimate_with_limits(Duration::from_secs(17), cached_response.clone()).unwrap();
-        assert_eq!(price, 97.84);
+        assert_eq!(price, f64::from(97.84));
         let price = estimate_with_limits(Duration::from_secs(19), cached_response.clone()).unwrap();
-        assert_eq!(price, 96.90666666666667);
+        assert_eq!(price, f64::from(96.90666666666667));
         let price = estimate_with_limits(Duration::from_secs(25), cached_response).unwrap();
-        assert_eq!(price, 96.0);
+        assert_eq!(price, f64::from(96.0));
     }
 }

--- a/src/ethgasstation.rs
+++ b/src/ethgasstation.rs
@@ -32,7 +32,7 @@ impl<T: Transport> EthGasStation<T> {
 
     async fn gas_price(&self) -> Result<Response> {
         self.transport
-            .get_json(API_URI, None)
+            .get_json(API_URI, Default::default())
             .await
             .context("failed to get ethgasstation gas price")
     }

--- a/src/ethgasstation.rs
+++ b/src/ethgasstation.rs
@@ -32,7 +32,7 @@ impl<T: Transport> EthGasStation<T> {
 
     async fn gas_price(&self) -> Result<Response> {
         self.transport
-            .get_json(API_URI)
+            .get_json(API_URI, None)
             .await
             .context("failed to get ethgasstation gas price")
     }

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -71,7 +71,7 @@ impl<T: Transport> GasNowGasStation<T> {
 
     async fn gas_price_without_cache(&self) -> Result<Response> {
         self.transport
-            .get_json(API_URI, None)
+            .get_json(API_URI, Default::default())
             .await
             .context("failed to get gasnow gas price")
     }

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -1,4 +1,4 @@
-use super::{linear_interpolation, GasPriceEstimating, Transport};
+use super::{linear_interpolation, CachedResponse, GasPriceEstimating, Transport};
 use anyhow::{anyhow, Context, Result};
 use futures::lock::Mutex;
 use std::{
@@ -14,14 +14,7 @@ const RATE_LIMIT: Duration = Duration::from_secs(15);
 
 pub struct GasNowGasStation<T> {
     transport: T,
-    last_response: Mutex<Option<CachedResponse>>,
-}
-
-struct CachedResponse {
-    // The time at which the request was sent.
-    time: Instant,
-    // The result of the last response. Error isn't Clone so we store None in the error case.
-    data: Option<Response>,
+    last_response: Mutex<Option<CachedResponse<Response>>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, serde::Deserialize, PartialEq)]

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -1,4 +1,4 @@
-use super::{linear_interpolation, CachedResponse, GasPriceEstimating, Transport};
+use super::{linear_interpolation, GasPriceEstimating, Transport};
 use anyhow::{anyhow, Context, Result};
 use futures::lock::Mutex;
 use std::{
@@ -14,7 +14,14 @@ const RATE_LIMIT: Duration = Duration::from_secs(15);
 
 pub struct GasNowGasStation<T> {
     transport: T,
-    last_response: Mutex<Option<CachedResponse<Response>>>,
+    last_response: Mutex<Option<CachedResponse>>,
+}
+
+struct CachedResponse {
+    // The time at which the request was sent.
+    time: Instant,
+    // The result of the last response. Error isn't Clone so we store None in the error case.
+    data: Option<Response>,
 }
 
 #[derive(Clone, Copy, Debug, Default, serde::Deserialize, PartialEq)]

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -71,7 +71,7 @@ impl<T: Transport> GasNowGasStation<T> {
 
     async fn gas_price_without_cache(&self) -> Result<Response> {
         self.transport
-            .get_json(API_URI)
+            .get_json(API_URI, None)
             .await
             .context("failed to get gasnow gas price")
     }

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -84,12 +84,7 @@ impl<T: Transport> GasNowGasStation<T> {
         // checked_duration_since to catch this.
         let mut lock = self.last_response.lock().await;
         match lock.as_ref() {
-            Some(cached)
-                if now
-                    .checked_duration_since(cached.time)
-                    .unwrap_or_else(|| Duration::from_secs(0))
-                    < RATE_LIMIT =>
-            {
+            Some(cached) if now.saturating_duration_since(cached.time) < RATE_LIMIT => {
                 match cached.data {
                     Some(response) => Ok(response),
                     None => Err(anyhow!(

--- a/src/gnosis_safe.rs
+++ b/src/gnosis_safe.rs
@@ -79,7 +79,7 @@ impl<T: Transport> GnosisSafeGasStation<T> {
     /// Retrieves the current gas prices from the gas station.
     pub async fn gas_prices(&self) -> Result<GasPrices> {
         self.transport
-            .get_json(&self.uri)
+            .get_json(&self.uri, None)
             .await
             .context("failed to get gnosissafe gas price")
     }

--- a/src/gnosis_safe.rs
+++ b/src/gnosis_safe.rs
@@ -79,7 +79,7 @@ impl<T: Transport> GnosisSafeGasStation<T> {
     /// Retrieves the current gas prices from the gas station.
     pub async fn gas_prices(&self) -> Result<GasPrices> {
         self.transport
-            .get_json(&self.uri, None)
+            .get_json(&self.uri, Default::default())
             .await
             .context("failed to get gnosissafe gas price")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! # Features
 //! `web3_`: Implements `GasPriceEstimating` for `Web3`.
 
+//#[cfg(feature = "tokio_")]
 pub mod blocknative;
 #[cfg(feature = "web3_")]
 pub mod eth_node;
@@ -21,7 +22,7 @@ pub use priority::PriorityGasPriceEstimating;
 
 use anyhow::Result;
 use serde::de::DeserializeOwned;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
 pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
@@ -45,6 +46,16 @@ pub trait Transport: Send + Sync {
         url: &str,
         header: http::header::HeaderMap,
     ) -> Result<T>;
+}
+
+/// Used for rate limit implementation. If requests are received at a higher rate then Gas price estimators
+/// can handle, we need to have a cached value that will be returned instead of error.
+#[derive(Debug)]
+pub struct CachedResponse<T> {
+    // The time at which the request was sent.
+    time: Instant,
+    // The result of the last response. Error isn't Clone so we store None in the error case.
+    data: Option<T>,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,12 +50,21 @@ pub trait Transport: Send + Sync {
 
 /// Used for rate limit implementation. If requests are received at a higher rate then Gas price estimators
 /// can handle, we need to have a cached value that will be returned instead of error.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CachedResponse<T> {
     // The time at which the request was sent.
     time: Instant,
     // The result of the last response. Error isn't Clone so we store None in the error case.
     data: Option<T>,
+}
+
+impl<T> Default for CachedResponse<T> {
+    fn default() -> Self {
+        Self {
+            time: Instant::now(),
+            data: Default::default(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use priority::PriorityGasPriceEstimating;
 
 use anyhow::Result;
 use serde::de::DeserializeOwned;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
 pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
@@ -46,25 +46,6 @@ pub trait Transport: Send + Sync {
         url: &str,
         header: http::header::HeaderMap,
     ) -> Result<T>;
-}
-
-/// Used for rate limit implementation. If requests are received at a higher rate then Gas price estimators
-/// can handle, we need to have a cached value that will be returned instead of error.
-#[derive(Debug, Clone)]
-pub struct CachedResponse<T> {
-    // The time at which the request was sent.
-    time: Instant,
-    // The result of the last response. Error isn't Clone so we store None in the error case.
-    data: Option<T>,
-}
-
-impl<T> Default for CachedResponse<T> {
-    fn default() -> Self {
-        Self {
-            time: Instant::now(),
-            data: Default::default(),
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added Blocknative gas estimator for legacy type of transactions.

Seems meaningful to have this as a separate PR.

Related to: https://github.com/gnosis/gp-v2-services/issues/1056 