### PR TITLE
blocknative supports 1559 transaction type

### DIFF
--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -202,11 +202,11 @@ fn estimate_with_limits(
                 gas_price_points.as_slice().try_into()?,
             ),
             gas_price_1559: Some(GasPrice1559 {
-                max_fee: linear_interpolation::interpolate(
+                max_fee_per_gas: linear_interpolation::interpolate(
                     time_limit.as_secs_f64(),
                     max_fee_per_gas_points.as_slice().try_into()?,
                 ),
-                max_priority_fee: linear_interpolation::interpolate(
+                max_priority_fee_per_gas: linear_interpolation::interpolate(
                     time_limit.as_secs_f64(),
                     max_priority_fee_per_gas_points.as_slice().try_into()?,
                 ),
@@ -332,8 +332,8 @@ mod tests {
             GasPrice {
                 gas_price: 104.0,
                 gas_price_1559: Some(GasPrice1559 {
-                    max_fee: 199.16,
-                    max_priority_fee: 9.86
+                    max_fee_per_gas: 199.16,
+                    max_priority_fee_per_gas: 9.86
                 })
             }
         );
@@ -343,8 +343,8 @@ mod tests {
             GasPrice {
                 gas_price: 98.76,
                 gas_price_1559: Some(GasPrice1559 {
-                    max_fee: 194.134,
-                    max_priority_fee: 4.844000000000001
+                    max_fee_per_gas: 194.134,
+                    max_priority_fee_per_gas: 4.844000000000001
                 })
             }
         );
@@ -354,8 +354,8 @@ mod tests {
             GasPrice {
                 gas_price: 97.84,
                 gas_price_1559: Some(GasPrice1559 {
-                    max_fee: 193.2612,
-                    max_priority_fee: 3.9696000000000007
+                    max_fee_per_gas: 193.2612,
+                    max_priority_fee_per_gas: 3.9696000000000007
                 })
             }
         );
@@ -365,8 +365,8 @@ mod tests {
             GasPrice {
                 gas_price: 96.90666666666667,
                 gas_price_1559: Some(GasPrice1559 {
-                    max_fee: 192.1552,
-                    max_priority_fee: 2.8552000000000004
+                    max_fee_per_gas: 192.1552,
+                    max_priority_fee_per_gas: 2.8552000000000004
                 })
             }
         );
@@ -376,8 +376,8 @@ mod tests {
             GasPrice {
                 gas_price: 96.0,
                 gas_price_1559: Some(GasPrice1559 {
-                    max_fee: 191.04,
-                    max_priority_fee: 1.74
+                    max_fee_per_gas: 191.04,
+                    max_priority_fee_per_gas: 1.74
                 })
             }
         );

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -132,14 +132,21 @@ impl BlockNative {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for BlockNative {
-    async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
+    async fn estimate_with_limits(
+        &self,
+        _gas_limit: f64,
+        time_limit: Duration,
+    ) -> Result<(f64, f64, f64)> {
         let cached_response = self.cached_response.lock().unwrap().clone();
 
         estimate_with_limits(time_limit, cached_response)
     }
 }
 
-fn estimate_with_limits(time_limit: Duration, mut cached_response: CachedResponse) -> Result<f64> {
+fn estimate_with_limits(
+    time_limit: Duration,
+    mut cached_response: CachedResponse,
+) -> Result<(f64, f64, f64)> {
     if Instant::now().saturating_duration_since(cached_response.time) > CACHED_RESPONSE_VALIDITY {
         return Err(anyhow!("cached response is stale"));
     }
@@ -158,13 +165,50 @@ fn estimate_with_limits(time_limit: Duration, mut cached_response: CachedRespons
                 (
                     TIME_PER_BLOCK.as_secs_f64() / (estimated_price.confidence / 100.0),
                     estimated_price.price,
+                    estimated_price.max_fee_per_gas,
+                    estimated_price.max_priority_fee_per_gas,
                 )
             })
+            .collect::<Vec<(f64, f64, f64, f64)>>();
+
+        let gas_price_points = points
+            .iter()
+            .map(
+                |(duration, gas_price, _max_fee_per_gas, _max_priority_fee_per_gas)| {
+                    (duration.clone(), gas_price.clone())
+                },
+            )
+            .collect::<Vec<(f64, f64)>>();
+        let max_fee_per_gas_points = points
+            .iter()
+            .map(
+                |(duration, _gas_price, max_fee_per_gas, _max_priority_fee_per_gas)| {
+                    (duration.clone(), max_fee_per_gas.clone())
+                },
+            )
+            .collect::<Vec<(f64, f64)>>();
+        let max_priority_fee_per_gas_points = points
+            .iter()
+            .map(
+                |(duration, _gas_price, _max_fee_per_gas, max_priority_fee_per_gas)| {
+                    (duration.clone(), max_priority_fee_per_gas.clone())
+                },
+            )
             .collect::<Vec<(f64, f64)>>();
 
-        return Ok(linear_interpolation::interpolate(
-            time_limit.as_secs_f64(),
-            points.as_slice().try_into()?,
+        return Ok((
+            linear_interpolation::interpolate(
+                time_limit.as_secs_f64(),
+                gas_price_points.as_slice().try_into()?,
+            ),
+            linear_interpolation::interpolate(
+                time_limit.as_secs_f64(),
+                max_fee_per_gas_points.as_slice().try_into()?,
+            ),
+            linear_interpolation::interpolate(
+                time_limit.as_secs_f64(),
+                max_priority_fee_per_gas_points.as_slice().try_into()?,
+            ),
         ));
     }
 
@@ -200,7 +244,7 @@ mod tests {
                     .estimate_with_limits(0.0, Duration::from_secs(20))
                     .await
                     .unwrap_or_default();
-                println!("res {}", res);
+                println!("res {:?}", res);
             }
         }
 
@@ -281,14 +325,14 @@ mod tests {
         };
 
         let price = estimate_with_limits(Duration::from_secs(10), cached_response.clone()).unwrap();
-        assert_eq!(price, 104.0);
+        assert_eq!(price, (104.0, 199.16, 9.86));
         let price = estimate_with_limits(Duration::from_secs(16), cached_response.clone()).unwrap();
-        assert_eq!(price, 98.76);
+        assert_eq!(price, (98.76, 194.134, 4.844000000000001));
         let price = estimate_with_limits(Duration::from_secs(17), cached_response.clone()).unwrap();
-        assert_eq!(price, 97.84);
+        assert_eq!(price, (97.84, 193.2612, 3.9696000000000007));
         let price = estimate_with_limits(Duration::from_secs(19), cached_response.clone()).unwrap();
-        assert_eq!(price, 96.90666666666667);
+        assert_eq!(price, (96.90666666666667, 192.1552, 2.8552000000000004));
         let price = estimate_with_limits(Duration::from_secs(25), cached_response).unwrap();
-        assert_eq!(price, 96.0);
+        assert_eq!(price, (96.0, 191.04, 1.74));
     }
 }

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -197,11 +197,11 @@ fn estimate_with_limits(
             .collect::<Vec<(f64, f64)>>();
 
         return Ok(GasPrice {
-            gas_price: linear_interpolation::interpolate(
+            legacy: linear_interpolation::interpolate(
                 time_limit.as_secs_f64(),
                 gas_price_points.as_slice().try_into()?,
             ),
-            gas_price_1559: Some(GasPrice1559 {
+            eip1559: Some(GasPrice1559 {
                 max_fee_per_gas: linear_interpolation::interpolate(
                     time_limit.as_secs_f64(),
                     max_fee_per_gas_points.as_slice().try_into()?,
@@ -330,8 +330,8 @@ mod tests {
         assert_eq!(
             price,
             GasPrice {
-                gas_price: 104.0,
-                gas_price_1559: Some(GasPrice1559 {
+                legacy: 104.0,
+                eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 199.16,
                     max_priority_fee_per_gas: 9.86
                 })
@@ -341,8 +341,8 @@ mod tests {
         assert_eq!(
             price,
             GasPrice {
-                gas_price: 98.76,
-                gas_price_1559: Some(GasPrice1559 {
+                legacy: 98.76,
+                eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 194.134,
                     max_priority_fee_per_gas: 4.844000000000001
                 })
@@ -352,8 +352,8 @@ mod tests {
         assert_eq!(
             price,
             GasPrice {
-                gas_price: 97.84,
-                gas_price_1559: Some(GasPrice1559 {
+                legacy: 97.84,
+                eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 193.2612,
                     max_priority_fee_per_gas: 3.9696000000000007
                 })
@@ -363,8 +363,8 @@ mod tests {
         assert_eq!(
             price,
             GasPrice {
-                gas_price: 96.90666666666667,
-                gas_price_1559: Some(GasPrice1559 {
+                legacy: 96.90666666666667,
+                eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 192.1552,
                     max_priority_fee_per_gas: 2.8552000000000004
                 })
@@ -374,8 +374,8 @@ mod tests {
         assert_eq!(
             price,
             GasPrice {
-                gas_price: 96.0,
-                gas_price_1559: Some(GasPrice1559 {
+                legacy: 96.0,
+                eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 191.04,
                     max_priority_fee_per_gas: 1.74
                 })

--- a/src/eth_node.rs
+++ b/src/eth_node.rs
@@ -17,7 +17,7 @@ where
         _gas_limit: f64,
         _time_limit: Duration,
     ) -> Result<GasPrice> {
-        let gas_price = self
+        let legacy = self
             .eth()
             .gas_price()
             .await
@@ -25,7 +25,7 @@ where
             .map(U256::to_f64_lossy)?;
 
         Ok(GasPrice {
-            gas_price,
+            legacy,
             ..Default::default()
         })
     }

--- a/src/eth_node.rs
+++ b/src/eth_node.rs
@@ -24,7 +24,7 @@ where
             .context("failed to get web3 gas price")
             .map(U256::to_f64_lossy)?;
 
-        Some(GasPrice {
+        Ok(GasPrice {
             gas_price,
             ..Default::default()
         })

--- a/src/eth_node.rs
+++ b/src/eth_node.rs
@@ -1,6 +1,6 @@
 //! Ethereum node `GasPriceEstimating` implementation.
 
-use super::GasPriceEstimating;
+use super::{GasPrice, GasPriceEstimating};
 use anyhow::{Context, Result};
 use primitive_types::U256;
 use std::time::Duration;
@@ -12,11 +12,21 @@ where
     T: Transport + Send + Sync,
     <T as Transport>::Out: Send,
 {
-    async fn estimate_with_limits(&self, _gas_limit: f64, _time_limit: Duration) -> Result<f64> {
-        self.eth()
+    async fn estimate_with_limits(
+        &self,
+        _gas_limit: f64,
+        _time_limit: Duration,
+    ) -> Result<GasPrice> {
+        let gas_price = self
+            .eth()
             .gas_price()
             .await
             .context("failed to get web3 gas price")
-            .map(U256::to_f64_lossy)
+            .map(U256::to_f64_lossy)?;
+
+        Some(GasPrice {
+            gas_price,
+            ..Default::default()
+        })
     }
 }

--- a/src/ethgasstation.rs
+++ b/src/ethgasstation.rs
@@ -1,4 +1,4 @@
-use super::{linear_interpolation, GasPriceEstimating, Transport};
+use super::{linear_interpolation, GasPrice, GasPriceEstimating, Transport};
 use anyhow::{Context, Result};
 use std::{convert::TryInto, time::Duration};
 
@@ -44,14 +44,14 @@ impl<T: Transport> GasPriceEstimating for EthGasStation<T> {
         &self,
         _gas_limit: f64,
         time_limit: Duration,
-    ) -> Result<(f64, f64, f64)> {
+    ) -> Result<GasPrice> {
         let response = self.gas_price().await?;
         let result = estimate_with_limits(&response, time_limit)?;
         Ok(result)
     }
 }
 
-fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<(f64, f64, f64)> {
+fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<GasPrice> {
     let time_limit_in_minutes = time_limit.as_secs_f64() / 60.0;
     // Ethgasstation sometimes has the same time value for fastest and fast (and also gas prices
     // within 5% of eachother). This is not allowed for the linear interpolation so we filter those
@@ -69,7 +69,10 @@ fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<(f6
     let gas_price_in_x10_gwei =
         linear_interpolation::interpolate(time_limit_in_minutes, points.as_slice().try_into()?);
     let gas_price_in_wei = gas_price_in_x10_gwei * 1e8;
-    Ok((gas_price_in_wei, Default::default(), Default::default()))
+    Ok(GasPrice {
+        gas_price: gas_price_in_wei,
+        ..Default::default()
+    })
 }
 
 #[cfg(test)]
@@ -90,7 +93,7 @@ mod tests {
             println!(
                 "gas price estimate for {} seconds: {} gwei",
                 time_limit.as_secs(),
-                price.0 / 1e9,
+                price.gas_price / 1e9,
             );
         }
     }

--- a/src/ethgasstation.rs
+++ b/src/ethgasstation.rs
@@ -70,7 +70,7 @@ fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<Gas
         linear_interpolation::interpolate(time_limit_in_minutes, points.as_slice().try_into()?);
     let gas_price_in_wei = gas_price_in_x10_gwei * 1e8;
     Ok(GasPrice {
-        gas_price: gas_price_in_wei,
+        legacy: gas_price_in_wei,
         ..Default::default()
     })
 }
@@ -93,7 +93,7 @@ mod tests {
             println!(
                 "gas price estimate for {} seconds: {} gwei",
                 time_limit.as_secs(),
-                price.gas_price / 1e9,
+                price.legacy / 1e9,
             );
         }
     }

--- a/src/ethgasstation.rs
+++ b/src/ethgasstation.rs
@@ -40,14 +40,18 @@ impl<T: Transport> EthGasStation<T> {
 
 #[async_trait::async_trait]
 impl<T: Transport> GasPriceEstimating for EthGasStation<T> {
-    async fn estimate_with_limits(&self, _gas_limit: f64, time_limit: Duration) -> Result<f64> {
+    async fn estimate_with_limits(
+        &self,
+        _gas_limit: f64,
+        time_limit: Duration,
+    ) -> Result<(f64, f64, f64)> {
         let response = self.gas_price().await?;
         let result = estimate_with_limits(&response, time_limit)?;
         Ok(result)
     }
 }
 
-fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<f64> {
+fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<(f64, f64, f64)> {
     let time_limit_in_minutes = time_limit.as_secs_f64() / 60.0;
     // Ethgasstation sometimes has the same time value for fastest and fast (and also gas prices
     // within 5% of eachother). This is not allowed for the linear interpolation so we filter those
@@ -65,7 +69,7 @@ fn estimate_with_limits(response: &Response, time_limit: Duration) -> Result<f64
     let gas_price_in_x10_gwei =
         linear_interpolation::interpolate(time_limit_in_minutes, points.as_slice().try_into()?);
     let gas_price_in_wei = gas_price_in_x10_gwei * 1e8;
-    Ok(gas_price_in_wei)
+    Ok((gas_price_in_wei, Default::default(), Default::default()))
 }
 
 #[cfg(test)]
@@ -86,7 +90,7 @@ mod tests {
             println!(
                 "gas price estimate for {} seconds: {} gwei",
                 time_limit.as_secs(),
-                price / 1e9,
+                price.0 / 1e9,
             );
         }
     }

--- a/src/gasnow.rs
+++ b/src/gasnow.rs
@@ -56,7 +56,7 @@ pub fn estimate_with_limits(
         (SLOW.as_secs_f64(), response.slow),
     ];
     Ok(GasPrice {
-        gas_price: linear_interpolation::interpolate(time_limit.as_secs_f64(), points.try_into()?),
+        legacy: linear_interpolation::interpolate(time_limit.as_secs_f64(), points.try_into()?),
         ..Default::default()
     })
 }
@@ -143,7 +143,7 @@ mod tests {
             slow: 1.0,
         };
         let result = estimate_with_limits(0., Duration::from_secs(20), &data).unwrap();
-        assert!(result.gas_price > 3.0 && result.gas_price < 4.0);
+        assert!(result.legacy > 3.0 && result.legacy < 4.0);
     }
 
     #[test]

--- a/src/gasnow_websocket.rs
+++ b/src/gasnow_websocket.rs
@@ -1,6 +1,6 @@
 use crate::{
     gasnow::{self, ResponseData},
-    GasPriceEstimating,
+    GasPrice, GasPriceEstimating,
 };
 use anyhow::{bail, ensure, Result};
 use futures::StreamExt;
@@ -66,7 +66,7 @@ impl GasPriceEstimating for GasNowWebSocketGasStation {
         &self,
         gas_limit: f64,
         time_limit: std::time::Duration,
-    ) -> Result<f64> {
+    ) -> Result<GasPrice> {
         if let Some((instant, response)) = *self.receiver.borrow() {
             ensure!(
                 instant.elapsed() <= self.max_update_age,

--- a/src/gnosis_safe.rs
+++ b/src/gnosis_safe.rs
@@ -92,7 +92,7 @@ impl<T: Transport> GasPriceEstimating for GnosisSafeGasStation<T> {
     async fn estimate(&self) -> Result<GasPrice> {
         let response = self.gas_prices().await?;
         Ok(GasPrice {
-            gas_price: response.fast,
+            legacy: response.fast,
             ..Default::default()
         })
     }
@@ -117,7 +117,7 @@ fn estimate_with_limits(
         (600.0, response.safe_low / 2.0),
     ];
     Ok(GasPrice {
-        gas_price: linear_interpolation::interpolate(time_limit.as_secs_f64(), points.try_into()?),
+        legacy: linear_interpolation::interpolate(time_limit.as_secs_f64(), points.try_into()?),
         ..Default::default()
     })
 }
@@ -160,7 +160,7 @@ pub mod tests {
             fastest: 500.0,
         };
         let estimate = estimate_with_limits(&price, 0.0, Duration::from_secs(30)).unwrap();
-        assert_approx_eq!(estimate.gas_price, 300.0);
+        assert_approx_eq!(estimate.legacy, 300.0);
     }
 
     // cargo test -p services-core gnosis_safe -- --ignored --nocapture
@@ -177,7 +177,7 @@ pub mod tests {
             println!(
                 "gas price estimate for {} seconds: {} gwei",
                 time_limit.as_secs(),
-                price.gas_price / 1e9,
+                price.legacy / 1e9,
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,20 +27,28 @@ use std::time::Duration;
 pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
 pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 
+#[derive(Debug, Default, PartialEq)]
+pub struct GasPrice1559 {
+    max_fee: f64,
+    max_priority_fee: f64,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct GasPrice {
+    gas_price: f64,
+    gas_price_1559: Option<GasPrice1559>,
+}
+
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait GasPriceEstimating: Send + Sync {
     /// Estimate the gas price for a transaction to be mined "quickly".
-    async fn estimate(&self) -> Result<(f64, f64, f64)> {
+    async fn estimate(&self) -> Result<GasPrice> {
         self.estimate_with_limits(DEFAULT_GAS_LIMIT, DEFAULT_TIME_LIMIT)
             .await
     }
     /// Estimate the gas price for a transaction that uses <gas> to be mined within <time_limit>.
-    async fn estimate_with_limits(
-        &self,
-        gas_limit: f64,
-        time_limit: Duration,
-    ) -> Result<(f64, f64, f64)>;
+    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<GasPrice>;
 }
 
 #[async_trait::async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Default, PartialEq)]
 pub struct GasPrice1559 {
-    max_fee: f64,
-    max_priority_fee: f64,
+    max_fee_per_gas: f64,
+    max_priority_fee_per_gas: f64,
 }
 
 #[derive(Debug, Default, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ pub struct GasPrice1559 {
 
 #[derive(Debug, Default, PartialEq)]
 pub struct GasPrice {
-    gas_price: f64,
-    gas_price_1559: Option<GasPrice1559>,
+    legacy: f64,
+    eip1559: Option<GasPrice1559>,
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Features
 //! `web3_`: Implements `GasPriceEstimating` for `Web3`.
 
-//#[cfg(feature = "tokio_")]
+#[cfg(feature = "tokio_")]
 pub mod blocknative;
 #[cfg(feature = "web3_")]
 pub mod eth_node;
@@ -31,12 +31,16 @@ pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 #[async_trait::async_trait]
 pub trait GasPriceEstimating: Send + Sync {
     /// Estimate the gas price for a transaction to be mined "quickly".
-    async fn estimate(&self) -> Result<f64> {
+    async fn estimate(&self) -> Result<(f64, f64, f64)> {
         self.estimate_with_limits(DEFAULT_GAS_LIMIT, DEFAULT_TIME_LIMIT)
             .await
     }
     /// Estimate the gas price for a transaction that uses <gas> to be mined within <time_limit>.
-    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64>;
+    async fn estimate_with_limits(
+        &self,
+        gas_limit: f64,
+        time_limit: Duration,
+    ) -> Result<(f64, f64, f64)>;
 }
 
 #[async_trait::async_trait]

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -85,7 +85,7 @@ mod tests {
 
         estimator_0.expect_estimate().times(1).returning(|| {
             Ok(GasPrice {
-                gas_price: 1.0,
+                legacy: 1.0,
                 ..Default::default()
             })
         });
@@ -93,7 +93,7 @@ mod tests {
         let priority =
             PriorityGasPriceEstimating::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
         let result = priority.estimate().now_or_never().unwrap().unwrap();
-        assert_approx_eq!(result.gas_price, 1.0);
+        assert_approx_eq!(result.legacy, 1.0);
     }
 
     #[test]
@@ -107,7 +107,7 @@ mod tests {
             .returning(|| Err(anyhow!("")));
         estimator_1.expect_estimate().times(1).returning(|| {
             Ok(GasPrice {
-                gas_price: 2.0,
+                legacy: 2.0,
                 ..Default::default()
             })
         });
@@ -115,7 +115,7 @@ mod tests {
         let priority =
             PriorityGasPriceEstimating::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
         let result = priority.estimate().now_or_never().unwrap().unwrap();
-        assert_approx_eq!(result.gas_price, 2.0);
+        assert_approx_eq!(result.legacy, 2.0);
     }
 
     #[test]

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -34,10 +34,10 @@ impl PriorityGasPriceEstimating {
         Self { estimators }
     }
 
-    async fn prioritize<'a, T, F>(&'a self, operation: T) -> Result<f64>
+    async fn prioritize<'a, T, F>(&'a self, operation: T) -> Result<(f64, f64, f64)>
     where
         T: Fn(&'a dyn GasPriceEstimating) -> F,
-        F: Future<Output = Result<f64>>,
+        F: Future<Output = Result<(f64, f64, f64)>>,
     {
         for (i, estimator) in self.estimators.iter().enumerate() {
             match operation(estimator.estimator.as_ref()).await {
@@ -61,12 +61,16 @@ impl PriorityGasPriceEstimating {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for PriorityGasPriceEstimating {
-    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<f64> {
+    async fn estimate_with_limits(
+        &self,
+        gas_limit: f64,
+        time_limit: Duration,
+    ) -> Result<(f64, f64, f64)> {
         self.prioritize(|estimator| estimator.estimate_with_limits(gas_limit, time_limit))
             .await
     }
 
-    async fn estimate(&self) -> Result<f64> {
+    async fn estimate(&self) -> Result<(f64, f64, f64)> {
         self.prioritize(|estimator| estimator.estimate()).await
     }
 }
@@ -83,12 +87,15 @@ mod tests {
         let mut estimator_0 = MockGasPriceEstimating::new();
         let estimator_1 = MockGasPriceEstimating::new();
 
-        estimator_0.expect_estimate().times(1).returning(|| Ok(1.0));
+        estimator_0
+            .expect_estimate()
+            .times(1)
+            .returning(|| Ok((1.0, Default::default(), Default::default())));
 
         let priority =
             PriorityGasPriceEstimating::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
         let result = priority.estimate().now_or_never().unwrap().unwrap();
-        assert_approx_eq!(result, 1.0);
+        assert_approx_eq!(result.0, 1.0);
     }
 
     #[test]
@@ -100,12 +107,15 @@ mod tests {
             .expect_estimate()
             .times(1)
             .returning(|| Err(anyhow!("")));
-        estimator_1.expect_estimate().times(1).returning(|| Ok(2.0));
+        estimator_1
+            .expect_estimate()
+            .times(1)
+            .returning(|| Ok((2.0, Default::default(), Default::default())));
 
         let priority =
             PriorityGasPriceEstimating::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
         let result = priority.estimate().now_or_never().unwrap().unwrap();
-        assert_approx_eq!(result, 2.0);
+        assert_approx_eq!(result.0, 2.0);
     }
 
     #[test]

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -1,4 +1,4 @@
-use super::GasPriceEstimating;
+use super::{GasPrice, GasPriceEstimating};
 use anyhow::{anyhow, Result};
 use std::{
     future::Future,
@@ -34,10 +34,10 @@ impl PriorityGasPriceEstimating {
         Self { estimators }
     }
 
-    async fn prioritize<'a, T, F>(&'a self, operation: T) -> Result<(f64, f64, f64)>
+    async fn prioritize<'a, T, F>(&'a self, operation: T) -> Result<GasPrice>
     where
         T: Fn(&'a dyn GasPriceEstimating) -> F,
-        F: Future<Output = Result<(f64, f64, f64)>>,
+        F: Future<Output = Result<GasPrice>>,
     {
         for (i, estimator) in self.estimators.iter().enumerate() {
             match operation(estimator.estimator.as_ref()).await {
@@ -61,16 +61,12 @@ impl PriorityGasPriceEstimating {
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for PriorityGasPriceEstimating {
-    async fn estimate_with_limits(
-        &self,
-        gas_limit: f64,
-        time_limit: Duration,
-    ) -> Result<(f64, f64, f64)> {
+    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<GasPrice> {
         self.prioritize(|estimator| estimator.estimate_with_limits(gas_limit, time_limit))
             .await
     }
 
-    async fn estimate(&self) -> Result<(f64, f64, f64)> {
+    async fn estimate(&self) -> Result<GasPrice> {
         self.prioritize(|estimator| estimator.estimate()).await
     }
 }
@@ -87,15 +83,17 @@ mod tests {
         let mut estimator_0 = MockGasPriceEstimating::new();
         let estimator_1 = MockGasPriceEstimating::new();
 
-        estimator_0
-            .expect_estimate()
-            .times(1)
-            .returning(|| Ok((1.0, Default::default(), Default::default())));
+        estimator_0.expect_estimate().times(1).returning(|| {
+            Ok(GasPrice {
+                gas_price: 1.0,
+                ..Default::default()
+            })
+        });
 
         let priority =
             PriorityGasPriceEstimating::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
         let result = priority.estimate().now_or_never().unwrap().unwrap();
-        assert_approx_eq!(result.0, 1.0);
+        assert_approx_eq!(result.gas_price, 1.0);
     }
 
     #[test]
@@ -107,15 +105,17 @@ mod tests {
             .expect_estimate()
             .times(1)
             .returning(|| Err(anyhow!("")));
-        estimator_1
-            .expect_estimate()
-            .times(1)
-            .returning(|| Ok((2.0, Default::default(), Default::default())));
+        estimator_1.expect_estimate().times(1).returning(|| {
+            Ok(GasPrice {
+                gas_price: 2.0,
+                ..Default::default()
+            })
+        });
 
         let priority =
             PriorityGasPriceEstimating::new(vec![Box::new(estimator_0), Box::new(estimator_1)]);
         let result = priority.estimate().now_or_never().unwrap().unwrap();
-        assert_approx_eq!(result.0, 2.0);
+        assert_approx_eq!(result.gas_price, 2.0);
     }
 
     #[test]


### PR DESCRIPTION
Gas estimators now return gasPrice and optionally <maxFeePerGas, maxPriorityFeePerGas>.

Related to https://github.com/gnosis/gp-v2-services/issues/1056