### PR TITLE
Add support for 1559 - additional changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.9", features = ["sync", "time"], optional = true }
 tokio-tungstenite = { version = "0.15", features = ["native-tls"], optional = true }
 tracing = "0.1"
 url = "2.0"
-web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="2e2d1dfa906aa2dff6312b97d0d5ba804e9c8c6e" }
+web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="2e2d1dfa906aa2dff6312b97d0d5ba804e9c8c6e", default-features = false, optional = true }
 http = "0.2.4"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.9", features = ["sync", "time"], optional = true }
 tokio-tungstenite = { version = "0.15", features = ["native-tls"], optional = true }
 tracing = "0.1"
 url = "2.0"
-web3 = { version = "0.17", default-features = false, optional = true }
+web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="2e2d1dfa906aa2dff6312b97d0d5ba804e9c8c6e" }
 http = "0.2.4"
 
 [features]

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -279,14 +279,14 @@ mod tests {
           "system": "ethereum",
           "network": "main",
           "unit": "gwei",
-          "maxPrice": "123",
-          "currentBlockNumber": "13005095",
-          "msSinceLastBlock": "3793",
+          "maxPrice": 123,
+          "currentBlockNumber": 13005095,
+          "msSinceLastBlock": 3793,
           "blockPrices": [
             {
-              "blockNumber": "13005096",
+              "blockNumber": 13005096,
               "baseFeePerGas": 94.647990462,
-              "estimatedTransactionCount": "137",
+              "estimatedTransactionCount": 137,
               "estimatedPrices": [
                 {
                   "confidence": 99,

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -29,6 +29,7 @@ struct EstimatedPrice {
 #[serde(rename_all = "camelCase")]
 struct BlockPrice {
     estimated_prices: Vec<EstimatedPrice>,
+    base_fee_per_gas: f64,
 }
 
 #[derive(Debug, serde::Deserialize, Clone, Default)]
@@ -210,6 +211,7 @@ fn estimate_with_limits(
                     time_limit.as_secs_f64(),
                     max_priority_fee_per_gas_points.as_slice().try_into()?,
                 ),
+                base_fee_per_gas: block.base_fee_per_gas,
             }),
         });
     }
@@ -283,7 +285,7 @@ mod tests {
           "blockPrices": [
             {
               "blockNumber": "13005096",
-              "baseFeePerGas": "94.647990462",
+              "baseFeePerGas": 94.647990462,
               "estimatedTransactionCount": "137",
               "estimatedPrices": [
                 {
@@ -333,7 +335,8 @@ mod tests {
                 legacy: 104.0,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 199.16,
-                    max_priority_fee_per_gas: 9.86
+                    max_priority_fee_per_gas: 9.86,
+                    base_fee_per_gas: 94.647990462,
                 })
             }
         );
@@ -344,7 +347,8 @@ mod tests {
                 legacy: 98.76,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 194.134,
-                    max_priority_fee_per_gas: 4.844000000000001
+                    max_priority_fee_per_gas: 4.844000000000001,
+                    base_fee_per_gas: 94.647990462,
                 })
             }
         );
@@ -355,7 +359,8 @@ mod tests {
                 legacy: 97.84,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 193.2612,
-                    max_priority_fee_per_gas: 3.9696000000000007
+                    max_priority_fee_per_gas: 3.9696000000000007,
+                    base_fee_per_gas: 94.647990462,
                 })
             }
         );
@@ -366,7 +371,8 @@ mod tests {
                 legacy: 96.90666666666667,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 192.1552,
-                    max_priority_fee_per_gas: 2.8552000000000004
+                    max_priority_fee_per_gas: 2.8552000000000004,
+                    base_fee_per_gas: 94.647990462,
                 })
             }
         );
@@ -377,7 +383,8 @@ mod tests {
                 legacy: 96.0,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 191.04,
-                    max_priority_fee_per_gas: 1.74
+                    max_priority_fee_per_gas: 1.74,
+                    base_fee_per_gas: 94.647990462,
                 })
             }
         );

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -176,7 +176,7 @@ fn estimate_with_limits(
             .iter()
             .map(
                 |(duration, gas_price, _max_fee_per_gas, _max_priority_fee_per_gas)| {
-                    (duration.clone(), gas_price.clone())
+                    (*duration, *gas_price)
                 },
             )
             .collect::<Vec<(f64, f64)>>();
@@ -184,7 +184,7 @@ fn estimate_with_limits(
             .iter()
             .map(
                 |(duration, _gas_price, max_fee_per_gas, _max_priority_fee_per_gas)| {
-                    (duration.clone(), max_fee_per_gas.clone())
+                    (*duration, *max_fee_per_gas)
                 },
             )
             .collect::<Vec<(f64, f64)>>();
@@ -192,7 +192,7 @@ fn estimate_with_limits(
             .iter()
             .map(
                 |(duration, _gas_price, _max_fee_per_gas, max_priority_fee_per_gas)| {
-                    (duration.clone(), max_priority_fee_per_gas.clone())
+                    (*duration, *max_priority_fee_per_gas)
                 },
             )
             .collect::<Vec<(f64, f64)>>();

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -1,4 +1,4 @@
-use super::{linear_interpolation, GasPrice, GasPrice1559, GasPriceEstimating, Transport};
+use super::{linear_interpolation, EstimatedGasPrice, GasPrice1559, GasPriceEstimating, Transport};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::{
@@ -137,7 +137,7 @@ impl GasPriceEstimating for BlockNative {
         &self,
         _gas_limit: f64,
         time_limit: Duration,
-    ) -> Result<GasPrice> {
+    ) -> Result<EstimatedGasPrice> {
         let cached_response = self.cached_response.lock().unwrap().clone();
 
         estimate_with_limits(time_limit, cached_response)
@@ -147,7 +147,7 @@ impl GasPriceEstimating for BlockNative {
 fn estimate_with_limits(
     time_limit: Duration,
     mut cached_response: CachedResponse,
-) -> Result<GasPrice> {
+) -> Result<EstimatedGasPrice> {
     if Instant::now().saturating_duration_since(cached_response.time) > CACHED_RESPONSE_VALIDITY {
         return Err(anyhow!("cached response is stale"));
     }
@@ -197,7 +197,7 @@ fn estimate_with_limits(
             )
             .collect::<Vec<(f64, f64)>>();
 
-        return Ok(GasPrice {
+        return Ok(EstimatedGasPrice {
             legacy: linear_interpolation::interpolate(
                 time_limit.as_secs_f64(),
                 gas_price_points.as_slice().try_into()?,
@@ -331,7 +331,7 @@ mod tests {
         let price = estimate_with_limits(Duration::from_secs(10), cached_response.clone()).unwrap();
         assert_eq!(
             price,
-            GasPrice {
+            EstimatedGasPrice {
                 legacy: 104.0,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 199.16,
@@ -343,7 +343,7 @@ mod tests {
         let price = estimate_with_limits(Duration::from_secs(16), cached_response.clone()).unwrap();
         assert_eq!(
             price,
-            GasPrice {
+            EstimatedGasPrice {
                 legacy: 98.76,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 194.134,
@@ -355,7 +355,7 @@ mod tests {
         let price = estimate_with_limits(Duration::from_secs(17), cached_response.clone()).unwrap();
         assert_eq!(
             price,
-            GasPrice {
+            EstimatedGasPrice {
                 legacy: 97.84,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 193.2612,
@@ -367,7 +367,7 @@ mod tests {
         let price = estimate_with_limits(Duration::from_secs(19), cached_response.clone()).unwrap();
         assert_eq!(
             price,
-            GasPrice {
+            EstimatedGasPrice {
                 legacy: 96.90666666666667,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 192.1552,
@@ -379,7 +379,7 @@ mod tests {
         let price = estimate_with_limits(Duration::from_secs(25), cached_response).unwrap();
         assert_eq!(
             price,
-            GasPrice {
+            EstimatedGasPrice {
                 legacy: 96.0,
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 191.04,

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -26,7 +26,7 @@ struct EstimatedPrice {
 }
 
 impl EstimatedPrice {
-    pub fn to_wei(self) -> Self {
+    pub fn gwei_to_wei(self) -> Self {
         Self {
             price: self.price * 1_000_000_000.0,
             max_fee_per_gas: self.max_fee_per_gas * 1_000_000_000.0,
@@ -44,13 +44,13 @@ struct BlockPrice {
 }
 
 impl BlockPrice {
-    pub fn to_wei(self) -> Self {
+    pub fn gwei_to_wei(self) -> Self {
         Self {
             base_fee_per_gas: self.base_fee_per_gas * 1_000_000_000.0,
             estimated_prices: self
                 .estimated_prices
                 .into_iter()
-                .map(|price| price.to_wei())
+                .map(|price| price.gwei_to_wei())
                 .collect(),
         }
     }
@@ -63,12 +63,12 @@ struct Response {
 }
 
 impl Response {
-    pub fn to_wei(self) -> Self {
+    pub fn gwei_to_wei(self) -> Self {
         Self {
             block_prices: self
                 .block_prices
                 .into_iter()
-                .map(|block| block.to_wei())
+                .map(|block| block.gwei_to_wei())
                 .collect(),
         }
     }
@@ -133,7 +133,7 @@ impl BlockNative {
             Ok(response) => {
                 *cached_response_clone.lock().unwrap() = CachedResponse {
                     time: Instant::now(),
-                    data: response.to_wei(),
+                    data: response.gwei_to_wei(),
                 };
             }
             Err(e) => {
@@ -150,7 +150,7 @@ impl BlockNative {
                     Ok(response) => {
                         *cached_response_clone.lock().unwrap() = CachedResponse {
                             time: Instant::now(),
-                            data: response.to_wei(),
+                            data: response.gwei_to_wei(),
                         };
                     }
                     Err(e) => tracing::warn!(?e, "failed to get response from blocknative"),

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -26,7 +26,7 @@ struct EstimatedPrice {
 }
 
 impl EstimatedPrice {
-    pub fn gwei_to_wei(self) -> Self {
+    fn gwei_to_wei(self) -> Self {
         Self {
             price: self.price * 1_000_000_000.0,
             max_fee_per_gas: self.max_fee_per_gas * 1_000_000_000.0,
@@ -44,7 +44,7 @@ struct BlockPrice {
 }
 
 impl BlockPrice {
-    pub fn gwei_to_wei(self) -> Self {
+    fn gwei_to_wei(self) -> Self {
         Self {
             base_fee_per_gas: self.base_fee_per_gas * 1_000_000_000.0,
             estimated_prices: self
@@ -63,7 +63,7 @@ struct Response {
 }
 
 impl Response {
-    pub fn gwei_to_wei(self) -> Self {
+    fn gwei_to_wei(self) -> Self {
         Self {
             block_prices: self
                 .block_prices

--- a/src/eth_node.rs
+++ b/src/eth_node.rs
@@ -1,6 +1,6 @@
 //! Ethereum node `GasPriceEstimating` implementation.
 
-use super::{GasPrice, GasPriceEstimating};
+use super::{EstimatedGasPrice, GasPriceEstimating};
 use anyhow::{Context, Result};
 use primitive_types::U256;
 use std::time::Duration;
@@ -16,7 +16,7 @@ where
         &self,
         _gas_limit: f64,
         _time_limit: Duration,
-    ) -> Result<GasPrice> {
+    ) -> Result<EstimatedGasPrice> {
         let legacy = self
             .eth()
             .gas_price()
@@ -24,7 +24,7 @@ where
             .context("failed to get web3 gas price")
             .map(U256::to_f64_lossy)?;
 
-        Ok(GasPrice {
+        Ok(EstimatedGasPrice {
             legacy,
             ..Default::default()
         })

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -39,7 +39,7 @@ impl EstimatedGasPrice {
     pub fn bump(self, factor: f64) -> Self {
         Self {
             legacy: self.legacy * factor,
-            eip1559: self.eip1559.and_then(|x| Some(x.bump(factor))),
+            eip1559: self.eip1559.map(|x| x.bump(factor)),
         }
     }
 
@@ -47,7 +47,7 @@ impl EstimatedGasPrice {
     pub fn ceil(self) -> Self {
         Self {
             legacy: self.legacy.ceil(),
-            eip1559: self.eip1559.and_then(|x| Some(x.ceil())),
+            eip1559: self.eip1559.map(|x| x.ceil()),
         }
     }
 
@@ -55,7 +55,7 @@ impl EstimatedGasPrice {
     pub fn limit_cap(self, cap: f64) -> Self {
         Self {
             legacy: self.legacy.min(cap),
-            eip1559: self.eip1559.and_then(|x| Some(x.limit_cap(cap))),
+            eip1559: self.eip1559.map(|x| x.limit_cap(cap)),
         }
     }
 }
@@ -106,11 +106,12 @@ impl GasPrice1559 {
 #[cfg(test)]
 mod tests {
     use crate::{EstimatedGasPrice, GasPrice1559};
+    use assert_approx_eq::assert_approx_eq;
 
     #[test]
     fn cap_legacy() {
         //assert legacy is returned
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 legacy: 1.0,
                 ..Default::default()
@@ -123,7 +124,7 @@ mod tests {
     #[test]
     fn cap_eip1559() {
         //assert eip1559 is returned
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 1.0,
@@ -139,7 +140,7 @@ mod tests {
     #[test]
     fn cap_legacy_and_eip1559() {
         //assert eip1559 is taken as default
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 legacy: 1.0,
                 eip1559: Some(GasPrice1559 {
@@ -234,7 +235,7 @@ mod tests {
     #[test]
     fn estimate_legacy() {
         //assert legacy estimation is returned
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 legacy: 1.0,
                 ..Default::default()
@@ -247,7 +248,7 @@ mod tests {
     #[test]
     fn estimate_eip1559() {
         //assert eip1559 estimation is returned
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 10.0,
@@ -260,7 +261,7 @@ mod tests {
             7.0
         );
 
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 10.0,
@@ -273,7 +274,7 @@ mod tests {
             10.0
         );
 
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 10.0,
@@ -289,7 +290,7 @@ mod tests {
 
     #[test]
     fn estimate_legacy_and_eip1559() {
-        assert_eq!(
+        assert_approx_eq!(
             EstimatedGasPrice {
                 eip1559: Some(GasPrice1559 {
                     max_fee_per_gas: 10.0,

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -35,6 +35,15 @@ impl EstimatedGasPrice {
         }
     }
 
+    // Maximum tip willing to pay to miners for transaction.
+    pub fn tip(&self) -> f64 {
+        if let Some(gas_price) = &self.eip1559 {
+            gas_price.max_priority_fee_per_gas
+        } else {
+            self.legacy
+        }
+    }
+
     // Bump gas price by factor.
     pub fn bump(self, factor: f64) -> Self {
         Self {

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -76,27 +76,24 @@ impl GasPrice1559 {
     // Bump maximum gas price by factor.
     pub fn bump_cap(self, factor: f64) -> Self {
         Self {
-            base_fee_per_gas: self.base_fee_per_gas,
             max_fee_per_gas: self.max_fee_per_gas * factor,
-            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            ..self
         }
     }
 
     // Ceil maximum gas price (since its defined as float).
     pub fn ceil_cap(self) -> Self {
         Self {
-            base_fee_per_gas: self.base_fee_per_gas,
             max_fee_per_gas: self.max_fee_per_gas.ceil(),
-            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            ..self
         }
     }
 
     // If current cap if higher then the input, set to input.
     pub fn limit_cap(self, cap: f64) -> Self {
         Self {
-            base_fee_per_gas: self.base_fee_per_gas,
             max_fee_per_gas: self.max_fee_per_gas.min(cap),
-            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            ..self
         }
     }
 }

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -11,10 +11,10 @@ pub struct EstimatedGasPrice {
 }
 
 impl EstimatedGasPrice {
-    // Estimate the gas price based on the current network conditions (base_fee_per_gas)
+    // Estimate the effective gas price based on the current network conditions (base_fee_per_gas)
     // Beware that gas price for mined transaction could be different from estimated value in case of 1559 tx
     // (because base_fee_per_gas can change between estimation and mining the tx).
-    pub fn estimate(&self) -> f64 {
+    pub fn effective_gas_price(&self) -> f64 {
         if let Some(gas_price) = &self.eip1559 {
             std::cmp::min_by(
                 gas_price.max_fee_per_gas,
@@ -240,7 +240,7 @@ mod tests {
                 legacy: 1.0,
                 ..Default::default()
             }
-            .estimate(),
+            .effective_gas_price(),
             1.0
         );
     }
@@ -257,7 +257,7 @@ mod tests {
                 }),
                 ..Default::default()
             }
-            .estimate(),
+            .effective_gas_price(),
             7.0
         );
 
@@ -270,7 +270,7 @@ mod tests {
                 }),
                 ..Default::default()
             }
-            .estimate(),
+            .effective_gas_price(),
             10.0
         );
 
@@ -283,7 +283,7 @@ mod tests {
                 }),
                 ..Default::default()
             }
-            .estimate(),
+            .effective_gas_price(),
             10.0
         );
     }
@@ -299,7 +299,7 @@ mod tests {
                 }),
                 legacy: 8.0
             }
-            .estimate(),
+            .effective_gas_price(),
             7.0
         );
     }

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -35,19 +35,19 @@ impl EstimatedGasPrice {
         }
     }
 
-    // Bump maximum gas price by factor.
-    pub fn bump_cap(self, factor: f64) -> Self {
+    // Bump gas price by factor.
+    pub fn bump(self, factor: f64) -> Self {
         Self {
             legacy: self.legacy * factor,
-            eip1559: self.eip1559.and_then(|x| Some(x.bump_cap(factor))),
+            eip1559: self.eip1559.and_then(|x| Some(x.bump(factor))),
         }
     }
 
-    // Ceil maximum gas price (since its defined as float).
-    pub fn ceil_cap(self) -> Self {
+    // Ceil gas price (since its defined as float).
+    pub fn ceil(self) -> Self {
         Self {
             legacy: self.legacy.ceil(),
-            eip1559: self.eip1559.and_then(|x| Some(x.ceil_cap())),
+            eip1559: self.eip1559.and_then(|x| Some(x.ceil())),
         }
     }
 
@@ -73,18 +73,20 @@ pub struct GasPrice1559 {
 }
 
 impl GasPrice1559 {
-    // Bump maximum gas price by factor.
-    pub fn bump_cap(self, factor: f64) -> Self {
+    // Bump gas price by factor.
+    pub fn bump(self, factor: f64) -> Self {
         Self {
             max_fee_per_gas: self.max_fee_per_gas * factor,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas * factor,
             ..self
         }
     }
 
-    // Ceil maximum gas price (since its defined as float).
-    pub fn ceil_cap(self) -> Self {
+    // Ceil gas price (since its defined as float).
+    pub fn ceil(self) -> Self {
         Self {
             max_fee_per_gas: self.max_fee_per_gas.ceil(),
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas.ceil(),
             ..self
         }
     }
@@ -93,6 +95,9 @@ impl GasPrice1559 {
     pub fn limit_cap(self, cap: f64) -> Self {
         Self {
             max_fee_per_gas: self.max_fee_per_gas.min(cap),
+            max_priority_fee_per_gas: self
+                .max_priority_fee_per_gas
+                .min(self.max_fee_per_gas.min(cap)), // enforce max_priority_fee_per_gas <= max_fee_per_gas
             ..self
         }
     }

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -1,0 +1,116 @@
+/// Gas price received from the gas price estimators.
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
+/// Main gas price structure.
+/// Provide estimated gas prices for both legacy and eip1559 transactions.
+pub struct GasPrice {
+    // Estimated gas price for legacy type of transactions.
+    pub legacy: f64,
+    // Estimated gas price for 1559 type of transactions. Optional because not all gas estimators support 1559.
+    pub eip1559: Option<GasPrice1559>,
+}
+
+impl GasPrice {
+    // Estimate the gas price based on the current network conditions (base_fee_per_gas)
+    // Beware that gas price for mined transaction could be different (because base_fee_per_gas 
+    // can change between estimation and mining the tx).
+    pub fn estimate_gas_price(&self) -> f64 {
+        if let Some(gas_price) = &self.eip1559 {
+            match gas_price
+                .max_fee_per_gas
+                .partial_cmp(&(gas_price.max_priority_fee_per_gas + gas_price.base_fee_per_gas))
+            {
+                Some(ordering) => match ordering {
+                    std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
+                        gas_price.max_fee_per_gas
+                    }
+                    std::cmp::Ordering::Greater => {
+                        gas_price.max_priority_fee_per_gas + gas_price.base_fee_per_gas
+                    }
+                },
+                None => gas_price.max_fee_per_gas,
+            }
+        } else {
+            self.legacy
+        }
+    }
+
+    // Maximum gas price willing to pay for the transaction.
+    pub fn cap(&self) -> f64 {
+        if let Some(gas_price) = &self.eip1559 {
+            gas_price.max_fee_per_gas
+        } else {
+            self.legacy
+        }
+    }
+
+    // Bump maximum gas price by factor.
+    pub fn bump_cap(self, factor: f64) -> Self {
+        Self {
+            legacy: self.legacy * factor,
+            eip1559: self.eip1559.and_then(|x| Some(x.bump_cap(factor))),
+        }
+    }
+
+    // Ceil maximum gas price (since its defined as float).
+    pub fn ceil_cap(self) -> Self {
+        Self {
+            legacy: self.legacy.ceil(),
+            eip1559: self.eip1559.and_then(|x| Some(x.ceil_cap())),
+        }
+    }
+
+    // If current cap if higher then the input, set to input.
+    pub fn limit_cap(self, cap: f64) -> Self {
+        Self {
+            legacy: self.legacy.min(cap),
+            eip1559: self.eip1559.and_then(|x| Some(x.limit_cap(cap))),
+        }
+    }
+}
+
+/// Gas price structure for 1559 transactions. 
+/// Contains base_fee_per_gas as an essential part of the gas price estimation.
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
+pub struct GasPrice1559 {
+    // Estimated base fee for the pending block (block currently being mined)
+    pub base_fee_per_gas: f64,
+    // Maximum gas price willing to pay for the transaction.
+    pub max_fee_per_gas: f64,
+    // Priority fee used to incentivize miners to include the tx in case of network congestion.
+    pub max_priority_fee_per_gas: f64,
+}
+
+impl GasPrice1559 {
+    // Bump maximum gas price by factor.
+    pub fn bump_cap(self, factor: f64) -> Self {
+        Self {
+            base_fee_per_gas: self.base_fee_per_gas,
+            max_fee_per_gas: self.max_fee_per_gas * factor,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+        }
+    }
+
+    // Ceil maximum gas price (since its defined as float).
+    pub fn ceil_cap(self) -> Self {
+        Self {
+            base_fee_per_gas: self.base_fee_per_gas,
+            max_fee_per_gas: self.max_fee_per_gas.ceil(),
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+        }
+    }
+
+    // If current cap if higher then the input, set to input.
+    pub fn limit_cap(self, cap: f64) -> Self {
+        Self {
+            base_fee_per_gas: self.base_fee_per_gas,
+            max_fee_per_gas: self.max_fee_per_gas.min(cap),
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // todo
+}

--- a/src/gasnow_websocket.rs
+++ b/src/gasnow_websocket.rs
@@ -1,6 +1,6 @@
 use crate::{
     gasnow::{self, ResponseData},
-    GasPrice, GasPriceEstimating,
+    EstimatedGasPrice, GasPriceEstimating,
 };
 use anyhow::{bail, ensure, Result};
 use futures::StreamExt;
@@ -66,7 +66,7 @@ impl GasPriceEstimating for GasNowWebSocketGasStation {
         &self,
         gas_limit: f64,
         time_limit: std::time::Duration,
-    ) -> Result<GasPrice> {
+    ) -> Result<EstimatedGasPrice> {
         if let Some((instant, response)) = *self.receiver.borrow() {
             ensure!(
                 instant.elapsed() <= self.max_update_age,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,18 +6,18 @@ pub mod blocknative;
 #[cfg(feature = "web3_")]
 pub mod eth_node;
 pub mod ethgasstation;
-pub mod gasnow;
 #[cfg(feature = "tokio_")]
 pub mod gas_price;
+pub mod gasnow;
 pub mod gasnow_websocket;
 pub mod gnosis_safe;
 mod linear_interpolation;
 pub mod priority;
 
 pub use ethgasstation::EthGasStation;
-pub use gasnow::GasNowGasStation;
 #[cfg(feature = "tokio_")]
 pub use gas_price::{EstimatedGasPrice, GasPrice1559};
+pub use gasnow::GasNowGasStation;
 pub use gasnow_websocket::GasNowWebSocketGasStation;
 pub use gnosis_safe::GnosisSafeGasStation;
 pub use priority::PriorityGasPriceEstimating;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,18 +6,18 @@ pub mod blocknative;
 #[cfg(feature = "web3_")]
 pub mod eth_node;
 pub mod ethgasstation;
-#[cfg(feature = "tokio_")]
 pub mod gas_price;
 pub mod gasnow;
+#[cfg(feature = "tokio_")]
 pub mod gasnow_websocket;
 pub mod gnosis_safe;
 mod linear_interpolation;
 pub mod priority;
 
 pub use ethgasstation::EthGasStation;
-#[cfg(feature = "tokio_")]
 pub use gas_price::{EstimatedGasPrice, GasPrice1559};
 pub use gasnow::GasNowGasStation;
+#[cfg(feature = "tokio_")]
 pub use gasnow_websocket::GasNowWebSocketGasStation;
 pub use gnosis_safe::GnosisSafeGasStation;
 pub use priority::PriorityGasPriceEstimating;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod priority;
 pub use ethgasstation::EthGasStation;
 pub use gasnow::GasNowGasStation;
 #[cfg(feature = "tokio_")]
-pub use gas_price::{GasPrice, GasPrice1559};
+pub use gas_price::{EstimatedGasPrice, GasPrice1559};
 pub use gasnow_websocket::GasNowWebSocketGasStation;
 pub use gnosis_safe::GnosisSafeGasStation;
 pub use priority::PriorityGasPriceEstimating;
@@ -33,12 +33,16 @@ pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 #[async_trait::async_trait]
 pub trait GasPriceEstimating: Send + Sync {
     /// Estimate the gas price for a transaction to be mined "quickly".
-    async fn estimate(&self) -> Result<GasPrice> {
+    async fn estimate(&self) -> Result<EstimatedGasPrice> {
         self.estimate_with_limits(DEFAULT_GAS_LIMIT, DEFAULT_TIME_LIMIT)
             .await
     }
     /// Estimate the gas price for a transaction that uses <gas> to be mined within <time_limit>.
-    async fn estimate_with_limits(&self, gas_limit: f64, time_limit: Duration) -> Result<GasPrice>;
+    async fn estimate_with_limits(
+        &self,
+        gas_limit: f64,
+        time_limit: Duration,
+    ) -> Result<EstimatedGasPrice>;
 }
 
 #[async_trait::async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,16 +27,54 @@ use std::time::Duration;
 pub const DEFAULT_GAS_LIMIT: f64 = 21000.0;
 pub const DEFAULT_TIME_LIMIT: Duration = Duration::from_secs(30);
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct GasPrice1559 {
+    base_fee_per_gas: f64,
     max_fee_per_gas: f64,
     max_priority_fee_per_gas: f64,
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct GasPrice {
     legacy: f64,
     eip1559: Option<GasPrice1559>,
+}
+
+impl GasPrice {
+    pub fn estimate_gas_price(&self) -> f64 {
+        if let Some(gas_price) = &self.eip1559 {
+            match gas_price
+                .max_fee_per_gas
+                .partial_cmp(&(gas_price.max_priority_fee_per_gas + gas_price.base_fee_per_gas))
+            {
+                Some(ordering) => match ordering {
+                    std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
+                        gas_price.max_fee_per_gas
+                    }
+                    std::cmp::Ordering::Greater => {
+                        gas_price.max_priority_fee_per_gas + gas_price.base_fee_per_gas
+                    }
+                },
+                None => gas_price.max_fee_per_gas,
+            }
+        } else {
+            self.legacy
+        }
+    }
+
+    pub fn bump(self, factor: f64) -> Self {
+        Self {
+            legacy: self.legacy * factor,
+            eip1559: match self.eip1559 {
+                Some(x) => Some(GasPrice1559 {
+                    base_fee_per_gas: x.base_fee_per_gas,
+                    max_fee_per_gas: x.max_fee_per_gas * factor,
+                    max_priority_fee_per_gas: x.max_priority_fee_per_gas,
+                }),
+                None => None,
+            },
+        }
+    }
 }
 
 #[cfg_attr(test, mockall::automock)]


### PR DESCRIPTION
This PR gives possibility for gas price estimators to return not only legacy gas price estimation, but also  Eip1559 gas price estimation.

Legacy gas price estimation contains SINGLE value for gas price.
Eip1559 gas price estimation contains three values: pair (maxFeePerGas, maxPriorityFeePerGas) that is used directly for sending Eip1559 transactions to Ethereum network, and baseFeePerGas, which is used together with pair to calculate (forecast) SINGLE value of gas price, that would be effective gas price if tx would be mined on Ethereum network (at this moment).

If specific gas price estimator have support for Eip1559 estimation, it is expected from it to return both legacy and 1559 estimation, and then it is up to the user of the gas price estimation to select which one to use. If not selected, Eip1559 estimation is used by default.

Related PRs:
https://github.com/gnosis/ethcontract-rs/pull/638
https://github.com/gnosis/gp-transaction-retry/pull/5
https://github.com/gnosis/gp-v2-services/pull/1166
https://github.com/gnosis/gp-v2-services/issues/1056