### PR TITLE
Added conversion from EstimatedGasPrice to GasPrice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,14 @@
 name = "gas-estimation"
 version = "0.1.0"
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
 futures = "0.3"
 primitive-types = { version = "0.10", features = ["fp-conversion"], optional = true }
-ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", branch = "eip1559", features = ["gas_price"] }
+ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", branch = "eip1559", features = ["gas_price"], optional = true}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 name = "gas-estimation"
 version = "0.1.0"
 edition = "2018"
-license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
 futures = "0.3"
 primitive-types = { version = "0.10", features = ["fp-conversion"], optional = true }
+ethcontract = { git = "https://github.com/gnosis/ethcontract-rs.git", branch = "eip1559", features = ["gas_price"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "1.6"

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -1,3 +1,4 @@
+use ethcontract::GasPrice;
 /// Gas price received from the gas price estimators.
 use serde::Serialize;
 
@@ -125,6 +126,16 @@ impl GasPrice1559 {
                 .max_priority_fee_per_gas
                 .min(self.max_fee_per_gas.min(cap)), // enforce max_priority_fee_per_gas <= max_fee_per_gas
             ..self
+        }
+    }
+}
+
+impl From<EstimatedGasPrice> for GasPrice {
+    fn from(gas_price: EstimatedGasPrice) -> Self {
+        if let Some(eip1559) = gas_price.eip1559 {
+            (eip1559.max_fee_per_gas, eip1559.max_priority_fee_per_gas).into()
+        } else {
+            gas_price.legacy.into()
         }
     }
 }


### PR DESCRIPTION
Added conversion from EstimatedGasPrice to GasPrice.
This conversion is used in multiple places in gp-v2-services repo, thus this PR will reduce code duplication.

Dependent on: https://github.com/gnosis/ethcontract-rs/pull/700