### PR TITLE
Do not set reward percentiles to None

### DIFF
--- a/src/nativegasestimator.rs
+++ b/src/nativegasestimator.rs
@@ -177,7 +177,7 @@ async fn suggest_fee<T: Transport + Send + Sync>(
         .fee_history(
             params.fee_history_blocks.into(),
             serde_json::from_value::<BlockNumber>("latest".into()).unwrap(),
-            None,
+            Some(vec![]),
         )
         .await?;
 


### PR DESCRIPTION
According to the spec this parameter is required and we saw that some
nodes reject the request if the parameter is None (null).

Will also make a fix for rust-web3 to remove the Option.