### PR TITLE
Sunce86/validate gas prices

### DIFF
--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -248,7 +248,7 @@ fn estimate_with_limits(
                 base_fee_per_gas: block.base_fee_per_gas,
             }),
         }
-        .valid();
+        .validate();
     }
 
     Err(anyhow!("no valid response exist"))

--- a/src/blocknative.rs
+++ b/src/blocknative.rs
@@ -231,7 +231,7 @@ fn estimate_with_limits(
             )
             .collect::<Vec<(f64, f64)>>();
 
-        return Ok(EstimatedGasPrice {
+        return EstimatedGasPrice {
             legacy: linear_interpolation::interpolate(
                 time_limit.as_secs_f64(),
                 gas_price_points.as_slice().try_into()?,
@@ -247,7 +247,8 @@ fn estimate_with_limits(
                 ),
                 base_fee_per_gas: block.base_fee_per_gas,
             }),
-        });
+        }
+        .valid();
     }
 
     Err(anyhow!("no valid response exist"))

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -80,11 +80,15 @@ impl EstimatedGasPrice {
         }
     }
 
+    // Validate against rules defined in https://eips.ethereum.org/EIPS/eip-1559
+    // max_fee_per_gas >= max_priority_fee_per_gas
+    // max_fee_per_gas >= base_fee_per_gas
     pub fn is_valid(&self) -> bool {
         self.cap() >= self.tip() && self.cap() >= self.base_fee()
     }
 
-    pub fn valid(self) -> Result<EstimatedGasPrice> {
+    // Validate and build Result based on the validation result
+    pub fn validate(self) -> Result<EstimatedGasPrice> {
         match self.is_valid() {
             true => Ok(self),
             false => Err(anyhow!("invalid gas price values: {:?}", self)),

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 /// Gas price received from the gas price estimators.
 use serde::Serialize;
 
@@ -29,20 +30,22 @@ impl EstimatedGasPrice {
 
     // Maximum gas price willing to pay for the transaction.
     pub fn cap(&self) -> f64 {
-        if let Some(gas_price) = &self.eip1559 {
-            gas_price.max_fee_per_gas
-        } else {
-            self.legacy
-        }
+        self.eip1559
+            .map(|x| x.max_fee_per_gas)
+            .unwrap_or(self.legacy)
     }
 
     // Maximum tip willing to pay to miners for transaction.
     pub fn tip(&self) -> f64 {
-        if let Some(gas_price) = &self.eip1559 {
-            gas_price.max_priority_fee_per_gas
-        } else {
-            self.legacy
-        }
+        self.eip1559
+            .map(|x| x.max_priority_fee_per_gas)
+            .unwrap_or(self.legacy)
+    }
+
+    pub fn base_fee(&self) -> f64 {
+        self.eip1559
+            .map(|x| x.base_fee_per_gas)
+            .unwrap_or(self.legacy)
     }
 
     // Bump gas price by factor.
@@ -74,6 +77,17 @@ impl EstimatedGasPrice {
         Self {
             legacy: self.legacy.min(cap),
             eip1559: self.eip1559.map(|x| x.limit_cap(cap)),
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.cap() >= self.tip() && self.cap() >= self.base_fee()
+    }
+
+    pub fn valid(self) -> Result<EstimatedGasPrice> {
+        match self.is_valid() {
+            true => Ok(self),
+            false => Err(anyhow!("invalid values returned")),
         }
     }
 }

--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -87,7 +87,7 @@ impl EstimatedGasPrice {
     pub fn valid(self) -> Result<EstimatedGasPrice> {
         match self.is_valid() {
             true => Ok(self),
-            false => Err(anyhow!("invalid values returned")),
+            false => Err(anyhow!("invalid gas price values: {:?}", self)),
         }
     }
 }

--- a/src/nativegasestimator.rs
+++ b/src/nativegasestimator.rs
@@ -450,7 +450,7 @@ fn estimate_with_limits(
         }),
         ..Default::default()
     }
-    .valid()
+    .validate()
 }
 
 #[cfg(test)]

--- a/src/nativegasestimator.rs
+++ b/src/nativegasestimator.rs
@@ -436,7 +436,7 @@ fn estimate_with_limits(
         return Err(anyhow!("no eip1559 estimate exist"));
     };
 
-    return Ok(EstimatedGasPrice {
+    EstimatedGasPrice {
         eip1559: Some(GasPrice1559 {
             max_fee_per_gas: linear_interpolation::interpolate(
                 time_limit.as_secs_f64(),
@@ -449,7 +449,8 @@ fn estimate_with_limits(
             base_fee_per_gas,
         }),
         ..Default::default()
-    });
+    }
+    .valid()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR fixes https://github.com/gnosis/gp-v2-services/issues/1607

We should not allow the invalid EstimatedGasPrice values to be returned to driver.

Note that this validation does not have effect for gas price estimators that return legacy gas price, therefore it is safe to return `self.legacy` as `base_fee_per_gas` in `pub fn base_fee(&self)`