### PR TITLE
Change max fee bumping

### DIFF
--- a/src/gas_price.rs
+++ b/src/gas_price.rs
@@ -35,6 +35,14 @@ impl EstimatedGasPrice {
             .unwrap_or(self.legacy)
     }
 
+    // Set maximum gas price willing to pay for the transaction.
+    pub fn set_cap(self, max_fee_per_gas: f64) -> Self {
+        Self {
+            legacy: max_fee_per_gas,
+            eip1559: self.eip1559.map(|x| x.set_cap(max_fee_per_gas)),
+        }
+    }
+
     // Maximum tip willing to pay to miners for transaction.
     pub fn tip(&self) -> f64 {
         self.eip1559
@@ -122,6 +130,14 @@ impl GasPrice1559 {
     pub fn bump_cap(self, factor: f64) -> Self {
         Self {
             max_fee_per_gas: self.max_fee_per_gas * factor,
+            ..self
+        }
+    }
+
+    // Set max gas price.
+    pub fn set_cap(self, max_fee_per_gas: f64) -> Self {
+        Self {
+            max_fee_per_gas,
             ..self
         }
     }

--- a/src/nativegasestimator.rs
+++ b/src/nativegasestimator.rs
@@ -41,6 +41,8 @@ pub struct Params {
     pub extra_priority_fee_boost: f64,
     // priority fee offered when there are no recent transactions
     pub fallback_priority_fee: f64,
+    // a coefficient to multiply base_fee_per_gas with, in order to increase chances of transaction inclusion
+    pub bump_cap_coefficient: f64,
     // number of blocks to consider for fee history calculation
     pub fee_history_blocks: u64,
 }
@@ -57,6 +59,7 @@ impl Default for Params {
             extra_priority_fee_ratio: 0.25,
             extra_priority_fee_boost: 1559.0,
             fallback_priority_fee: 2e9,
+            bump_cap_coefficient: 2.0,
             fee_history_blocks: 300,
         }
     }
@@ -111,7 +114,10 @@ impl NativeGasEstimator {
                 let fees = fees
                     .into_iter()
                     .map(|(time_limit, gas_price)| {
-                        (time_limit, gas_price.set_cap(gas_price.base_fee() * 2.))
+                        (
+                            time_limit,
+                            gas_price.set_cap(gas_price.base_fee() * params.bump_cap_coefficient),
+                        )
                     })
                     .collect();
 
@@ -139,7 +145,12 @@ impl NativeGasEstimator {
                         let fees = fees
                             .into_iter()
                             .map(|(time_limit, gas_price)| {
-                                (time_limit, gas_price.set_cap(gas_price.base_fee() * 2.))
+                                (
+                                    time_limit,
+                                    gas_price.set_cap(
+                                        gas_price.base_fee() * params.bump_cap_coefficient,
+                                    ),
+                                )
                             })
                             .collect();
 

--- a/src/nativegasestimator.rs
+++ b/src/nativegasestimator.rs
@@ -6,7 +6,6 @@ use std::{
     convert::TryInto,
     f64::consts::{E, PI},
     fmt::Debug,
-    ops::Mul,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -112,7 +111,7 @@ impl NativeGasEstimator {
                 let fees = fees
                     .into_iter()
                     .map(|(time_limit, gas_price)| {
-                        (time_limit, gas_price.set_cap(gas_price.base_fee().mul(2.)))
+                        (time_limit, gas_price.set_cap(gas_price.base_fee() * 2.))
                     })
                     .collect();
 
@@ -140,7 +139,7 @@ impl NativeGasEstimator {
                         let fees = fees
                             .into_iter()
                             .map(|(time_limit, gas_price)| {
-                                (time_limit, gas_price.set_cap(gas_price.base_fee().mul(2.)))
+                                (time_limit, gas_price.set_cap(gas_price.base_fee() * 2.))
                             })
                             .collect();
 

--- a/src/nativegasestimator.rs
+++ b/src/nativegasestimator.rs
@@ -6,6 +6,7 @@ use std::{
     convert::TryInto,
     f64::consts::{E, PI},
     fmt::Debug,
+    ops::Mul,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -41,8 +42,6 @@ pub struct Params {
     pub extra_priority_fee_boost: f64,
     // priority fee offered when there are no recent transactions
     pub fallback_priority_fee: f64,
-    // a coefficient to multiply max_fee_per_gas with, in order to increase chances of transaction inclusion
-    pub bump_cap_coefficient: f64,
     // number of blocks to consider for fee history calculation
     pub fee_history_blocks: u64,
 }
@@ -59,7 +58,6 @@ impl Default for Params {
             extra_priority_fee_ratio: 0.25,
             extra_priority_fee_boost: 1559.0,
             fallback_priority_fee: 2e9,
-            bump_cap_coefficient: 2.0,
             fee_history_blocks: 300,
         }
     }
@@ -114,7 +112,7 @@ impl NativeGasEstimator {
                 let fees = fees
                     .into_iter()
                     .map(|(time_limit, gas_price)| {
-                        (time_limit, gas_price.bump_cap(params.bump_cap_coefficient))
+                        (time_limit, gas_price.set_cap(gas_price.base_fee().mul(2.)))
                     })
                     .collect();
 
@@ -142,7 +140,7 @@ impl NativeGasEstimator {
                         let fees = fees
                             .into_iter()
                             .map(|(time_limit, gas_price)| {
-                                (time_limit, gas_price.bump_cap(params.bump_cap_coefficient))
+                                (time_limit, gas_price.set_cap(gas_price.base_fee().mul(2.)))
                             })
                             .collect();
 


### PR DESCRIPTION
Fixes https://github.com/gnosis/gp-gas-estimation/issues/25

Originally, there was a bumping of 2x for `max_fee_per_gas` https://github.com/gnosis/gp-gas-estimation/blob/c79db13c8481774554c3538ae0662b658eb40278/src/nativegasestimator.rs#L113)

in order to be as close to BlockNative results as possible. The issue is that the previous implementation assumed the `max_fee_per_gas` is quite close to `base_fee_per_gas`.

Now, we explicitly set it to be `max_fee_per_gas = base_fee_per_gas * 2`